### PR TITLE
Skip directories when searching for assets

### DIFF
--- a/lib/themes_for_rails/assets_controller.rb
+++ b/lib/themes_for_rails/assets_controller.rb
@@ -72,10 +72,10 @@ module ThemesForRails
       path = asset_path(asset_name, asset_theme, asset_type)
       default_path = default_asset_path(asset_name, asset_theme, asset_type)
 
-      if File.exists?(path)
+      if File.exists?(path) && !File.directory?(path)
         yield path, mime_type_for(request)
 
-      elsif File.exists?(default_path)
+      elsif File.exists?(default_path) && !File.directory?(default_path)
         yield default_path, mime_type_for(request)
 
       elsif File.extname(path).blank?


### PR DESCRIPTION
Consider the following file structure:

* themes
  * default
    * team
      * 1.jpg
      * 2.jpg
  * theme1
    * team.jpg

Then, `find_themed_asset` method will try to serve the `team` folder as an asset, because `File#exist?` returns true for directories.